### PR TITLE
EDODSO-2111: Fix windows-2022-base packer template

### DIFF
--- a/images/windows/templates/windows-2022-base.pkr.hcl
+++ b/images/windows/templates/windows-2022-base.pkr.hcl
@@ -289,7 +289,8 @@ build {
       "${path.root}/../scripts/build/Install-DockerCompose.ps1",
       "${path.root}/../scripts/build/Install-PowershellCore.ps1",
       "${path.root}/../scripts/build/Install-WebPlatformInstaller.ps1",
-      "${path.root}/../scripts/build/Install-Runner.ps1"
+      "${path.root}/../scripts/build/Install-Runner.ps1",
+      "${path.root}/../scripts/build/Install-TortoiseSvn.ps1"
     ]
   }
 


### PR DESCRIPTION
## Work Items or Jira tickets
[EDODSO-2111](https://eaton-corp.atlassian.net/browse/EDODSO-2111)

## Pull requests dependencies
None

## What I changed
Sync'ed with windows-2022.pkr.hcl (svn was missing)

## What I tested
- [x] Compile a viable VM image version

## Steps prior to requesting review
- [x] Assign the pull request to someone (usually yourself)
- [x] List related Work Items or Jira ticket
- [x] Pull requests dependencies
- [x] Validate the assigned reviewers
- [x] Self Review
- [x] All tests passed

[EDODSO-2111]: https://eaton-corp.atlassian.net/browse/EDODSO-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ